### PR TITLE
Bump globalid minimum version to 1.0

### DIFF
--- a/downstream.gemspec
+++ b/downstream.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "after_commit_everywhere", "~> 1.0"
-  spec.add_dependency "globalid", "~> 0.5"
+  spec.add_dependency "globalid", "~> 1.0"
   spec.add_dependency "rails", ">= 6"
 
   spec.add_development_dependency "appraisal", "~> 2.2"


### PR DESCRIPTION
# Context

GlobalID has reached 1.0 and the changes between 0.5.0 and 1.0 are minimal. From the GlobalID [releases](https://github.com/rails/globalid/releases) page:
- 0.6.0: Add ActiveRecord::FixtureSet.signed_global_id helper to generate signed ids inside fixtures.
- 1.0.0 The code is the same as the 0.6.0 release.

## Related tickets

I didn't open a ticket. Let me know if it's necessary and I'll do so :) 

# What's inside

- [x] Bump GlobalID version to `~> 1.0`

# Checklist:
No item in this checklist should be necessary since the changes to GlobalID are so small.

- [ ] I have added tests
- [ ] I have made corresponding changes to the documentation
