### PR TITLE
Use released version of Rails 7

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -6,6 +6,6 @@ end
 
 if RUBY_VERSION >= "2.7"
   appraise "rails-7" do
-    gem "rails", "~> 7.0.0.alpha2"
+    gem "rails", "~> 7.0.0"
   end
 end


### PR DESCRIPTION
# Context
Now that Rails 7 has been released it'd be good to test against that version instead of the alpha. 

I am seeing some strange behaviour in a Rails 7 app and I'm thinking there might have been a change between alpha and final. The latest ActiveSupport version changed stuff [here](https://github.com/rails/rails/blob/79b0ffc4df3ae7b4ab2fb66aae4eb7fc0b01c472/activesupport/lib/active_support/notifications/fanout.rb#L101) and I'm seeing some errors in my apps in this point.

I don't quite have the time at the moment to setup the downstream dev env in my local machine so I'd love to rely on the CI for this one if possible. I know it's not ideal but I can't set it up at the moment.

## Related tickets
No ticket yet. I'd like for the test suite to run to see if my hunch is right.


# What's inside

- [x] Update appraisal's rails 7 version


# Checklist:

Not really needed.
- [ ] I have added tests
- [ ] I have made corresponding changes to the documentation
