### PR TITLE
fix compatibility with Rails 7

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -6,6 +6,6 @@ end
 
 if RUBY_VERSION >= "2.7"
   appraise "rails-7" do
-    gem "rails", "~> 7.0.0.alpha2"
+    gem "rails", "~> 7.0"
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ruby:
-    image: ruby:${RUBY_IMAGE:-3.0}-buster
+    image: ruby:${RUBY_IMAGE:-3.0}
     environment:
       - HISTFILE=/app/tmp/.bash_history
       - BUNDLE_PATH=/bundle

--- a/lefthook-local.dip_example.yml
+++ b/lefthook-local.dip_example.yml
@@ -1,4 +1,4 @@
 pre-commit:
   commands:
     rubocop:
-      runner: dip {cmd}
+      run: dip {cmd}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,5 +2,5 @@ pre-commit:
   commands:
     rubocop:
       tags: backend
-      glob: "**/*.rb"
-      runner: bundle exec rubocop -A {staged_files} && git add {staged_files}
+      glob: "{**/*.rb,*.rb,Gemfile,Rakefile,Appraisals}"
+      run: bundle exec rubocop -A --force-exclusion {staged_files} && git add {staged_files}

--- a/lib/downstream/config.rb
+++ b/lib/downstream/config.rb
@@ -17,10 +17,10 @@ module Downstream
 
     def pubsub=(value)
       @pubsub = case value
-        when String, Symbol
-          lookup_pubsub(value)
-        else
-          value
+      when String, Symbol
+        lookup_pubsub(value)
+      else
+        value
       end
     end
 

--- a/lib/downstream/pubsub_adapters/stateless/pubsub.rb
+++ b/lib/downstream/pubsub_adapters/stateless/pubsub.rb
@@ -19,7 +19,7 @@ module Downstream
       end
 
       def publish(identifier, event)
-        ActiveSupport::Notifications.publish(identifier, event)
+        ActiveSupport::Notifications.instrument(identifier, event)
       end
     end
   end

--- a/lib/downstream/pubsub_adapters/stateless/subscriber.rb
+++ b/lib/downstream/pubsub_adapters/stateless/subscriber.rb
@@ -16,7 +16,7 @@ module Downstream
         !!async
       end
 
-      def call(_name, event)
+      def call(_name, _start, _finish, _id, event)
         if async?
           if callable.is_a?(Proc) || callable.name.nil?
             raise ArgumentError, "Anonymous subscribers (blocks/procs/lambdas or anonymous modules) cannot be asynchronous"

--- a/spec/requests/server_timing_spec.rb
+++ b/spec/requests/server_timing_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+class ServerTimingsController < ActionController::Base
+  def index
+    Downstream.publish Downstream::TestEvent.new(user_id: 15)
+    head :ok
+  end
+end
+
+Rails.application.routes.draw do
+  get "/server-timings-test" => "server_timings#index"
+end
+
+describe "Compatibility with Server Timing controller middleware", type: :request do
+  it "works" do
+    expect { get "/server-timings-test" }
+      .to have_published_event(Downstream::TestEvent).with(user_id: 15)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ Combustion.initialize! :active_record, :action_controller, :active_job do
   config.logger = Logger.new(nil)
   config.log_level = :fatal
   config.active_job.queue_adapter = :test
+  config.server_timing = true
 end
 
 require "rspec/rails"


### PR DESCRIPTION
# Context

Rails 7 added ServerTiming middleware that subscribes to all events so that we need to publish events in a certain format.

https://github.com/rails/rails/pull/36289
https://github.com/activeadmin/activeadmin/pull/7262

<!--
Short description about the feature and the motivation/issue behind it
-->

## Related tickets

Closes #7

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Don't use low-level method `publish`
- [x] Minor updates

# Checklist:

- [x] I have added tests
